### PR TITLE
Add assert to Storage constructor

### DIFF
--- a/src/main/java/duke/storage/Storage.java
+++ b/src/main/java/duke/storage/Storage.java
@@ -31,6 +31,7 @@ public class Storage {
      */
     public Storage(String filePath) {
         this.filePath = filePath;
+        assert (filePath.equals("data/duke.txt"));
     }
 
     /**


### PR DESCRIPTION
Error occurs up when the filepath is wrongly declared, and the task attribute is not updated upon calling of load() method in Storage class

Need to assert the correct filepath so the task attribute gets correctly updated

Add an assert declaration to check for the correct filepath, allowing us to ensure the filepaths is correct, and the task attribute updated correctly